### PR TITLE
Fix: Prevent coverage upload on forked PRs in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ before_build:
 - ps: $env:SONAR_ORGANIZATION = "$env:APPVEYOR_REPO_NAME" -replace "/.*$",""
 - ps: $env:LOCAL_PR = 0
 - ps: if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { $env:LOCAL_PR = 1 }
-- ps: if($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -Eq $env:APPVEYOR_REPO_NAME) { $env:LOCAL_PR = 1 }
+- ps: if($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -Eq $env:APPVEYOR_REPO_NAME -or -Not $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME) { $env:LOCAL_PR = 1 }
 - cmd: nuget restore
 - cmd: choco install opencover.portable
 - cmd: choco install codecov
@@ -71,7 +71,12 @@ build_script:
       }
   - if %LOCAL_PR% EQU 1 codecov -f "Tests\%SOLUTION_NAME%.Tests\coverage.net8.0.opencover.xml"
   - if %LOCAL_PR% EQU 1 codeclimate-test-reporter format-coverage -t lcov -o "Tests\%SOLUTION_NAME%.Tests\code-climate.json" "Tests\%SOLUTION_NAME%.Tests\coverage.net8.0.info"
-  - if %LOCAL_PR% EQU 1 codeclimate-test-reporter upload-coverage -i "Tests\%SOLUTION_NAME%.Tests\code-climate.json" -r %CODECLIMATE_TOKEN%
+- if %LOCAL_PR% EQU 1 (
+    echo "Uploading coverage report..."
+    codeclimate-test-reporter upload-coverage -i "Tests\%SOLUTION_NAME%.Tests\code-climate.json" -r %CODECLIMATE_TOKEN%
+  ) else (
+    echo "Skipping coverage upload due to forked PR"
+  )
   - if %LOCAL_PR% EQU 1 java -jar ./codacy-test-reporter.jar report -l CSharp -t %CODACY_PROJECT_TOKEN% -r "Tests\%SOLUTION_NAME%.Tests\coverage.net8.0.opencover.xml"
   - if %LOCAL_PR% EQU 1 dotnet sonarscanner end /d:sonar.token="%SONAR_TOKEN%"
 


### PR DESCRIPTION
### **User description**
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [x] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.-->



> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Enhanced the AppVeyor configuration to prevent coverage uploads for forked pull requests.
- Added informative echo statements to indicate whether coverage upload is being skipped or executed.
- Improved the conditional logic for determining local PR status.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appveyor.yml</strong><dd><code>Improve coverage upload handling in AppVeyor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

appveyor.yml
<li>Updated logic to prevent coverage upload on forked PRs.<br> <li> Added conditional echo statements for clarity on coverage upload <br>status.<br> <li> Enhanced readability of the coverage upload section.<br>


</details>


  </td>
  <td><a href="https://github.com/GuilhermeStracini/apiclient-boilerplate-dotnet/pull/304/files#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined the build process to better differentiate internal from external contributions.
	- Enhanced messaging during builds to clearly indicate when coverage reports are being processed or skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->